### PR TITLE
read and write using standard pandas format

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -23,6 +23,20 @@ Functions
 
 .. autofunction:: evosim.charging_posts.random_charging_posts
 
+.. autofunction:: evosim.charging_posts.to_sockets
+
+.. autofunction:: evosim.charging_posts.to_chargers
+
+.. autofunction:: evosim.charging_posts.to_charging_posts
+
+.. autofunction:: evosim.charging_posts.is_charging_posts
+
+Data
+----
+
+.. autodata:: evosim.charging_posts.CHARGING_POSTS_SCHEMA
+
+
 Electric Vehicles
 =================
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -52,6 +52,17 @@ Functions
 
 .. autofunction:: evosim.fleet.random_fleet
 
+.. autofunction:: evosim.fleet.to_models
+
+.. autofunction:: evosim.fleet.is_fleet
+
+.. autofunction:: evosim.fleet.to_fleet
+
+Data
+----
+
+.. autodata:: evosim.fleet.FLEET_SCHEMA
+
 
 Matchers
 ========

--- a/src/evosim/allocators.rst
+++ b/src/evosim/allocators.rst
@@ -56,6 +56,7 @@ follows:
     dtype: bool
 
     >>> result.allocation.iloc[:10]
+    vehicle
     376    <NA>
     16       30
     365      13
@@ -94,6 +95,7 @@ We can also check that each that the allocation targeted available space only:
     >>> allocation = result.allocation.value_counts().reindex_like(charging_posts)
     >>> occupancy = allocation + charging_posts.occupancy
     >>> occupancy
+    post
     83    2
     30    3
     56    2
@@ -140,19 +142,21 @@ vehicle to the nearest compatible post.
 
     >>> result = evosim.allocators.greedy_allocator(fleet, charging_posts, matcher)
     >>> result.iloc[:5]
-         latitude  longitude socket charger  dest_lat  dest_long                   model  \
-    376     51.29       1.05  TYPE2    SLOW     51.37       0.91  HYUNDAI_IONIQ_ELECTRIC
-    16      51.32       1.20  TYPE2    FAST     51.38       0.83     MERCEDES_BENZ_E350E
-    365     51.42       0.84  TYPE2    SLOW     51.59       0.22                  BMW_I3
-    82      51.46       0.73  TYPE2    FAST     51.53       0.60              BMW_X5_40E
-    107     51.67      -0.47  TYPE2    SLOW     51.53      -0.16           JAGUAR_I_PACE
+             latitude  longitude socket charger  dest_lat  dest_long  \
+    vehicle
+    376         51.29       1.05  TYPE2    SLOW     51.37       0.91
+    16          51.32       1.20  TYPE2    FAST     51.38       0.83
+    365         51.42       0.84  TYPE2    SLOW     51.59       0.22
+    82          51.46       0.73  TYPE2    FAST     51.53       0.60
+    107         51.67      -0.47  TYPE2    SLOW     51.53      -0.16
     <BLANKLINE>
-         allocation
-    376          13
-    16           30
-    365          27
-    82           23
-    107        <NA>
+                              model  allocation
+    vehicle
+    376      HYUNDAI_IONIQ_ELECTRIC          13
+    16          MERCEDES_BENZ_E350E          30
+    365                      BMW_I3          27
+    82                   BMW_X5_40E          23
+    107               JAGUAR_I_PACE        <NA>
 
 In the same vein as for :py:func:`~evosim.allocators.random_allocator`, the function
 returns a shallow copy of the ``fleet`` with an ``allocation`` column holding the label

--- a/src/evosim/charging_posts.py
+++ b/src/evosim/charging_posts.py
@@ -196,7 +196,7 @@ def is_charging_posts(dataframe: pd.DataFrame, raise_exception: bool = False) ->
         >>> from pytest import raises
         >>> from evosim.charging_posts import random_charging_posts, is_charging_posts
         >>> posts = random_charging_posts(5)
-        >>> is_charging_posts(posts)
+        >>> is_charging_posts(posts, raise_exception=True)
         True
 
         >>> is_charging_posts(posts.drop(columns="latitude"))

--- a/src/evosim/charging_posts.py
+++ b/src/evosim/charging_posts.py
@@ -161,7 +161,7 @@ def random_charging_posts(
             rng.integers(low=occupancy[0], high=occupancy[1], size=n) % capacities
         )
 
-    return pd.DataFrame(
+    result = pd.DataFrame(
         dict(
             latitude=lat,
             longitude=lon,
@@ -171,3 +171,5 @@ def random_charging_posts(
             occupancy=occupancies,
         )
     )
+    result.index.name = "post"
+    return result

--- a/src/evosim/charging_posts.py
+++ b/src/evosim/charging_posts.py
@@ -130,18 +130,19 @@ def to_chargers(data: Union[Sequence[Text], Text]) -> Sequence[Chargers]:
 CHARGING_POSTS_SCHEMA: Mapping[
     Text, Union[np.dtype, Callable[[Sequence], Sequence], Sequence[np.dtype]]
 ] = dict(
-    latitude=np.dtype(float),
-    longitude=np.dtype(float),
-    capacity=np.dtype(int),
-    occupancy=np.dtype(int),
+    latitude=(np.dtype(float), np.float16, np.float32, np.float64),
+    longitude=(np.dtype(float), np.float16, np.float32, np.float64),
+    capacity=(np.dtype(int), np.int8, np.int16, np.int32, np.int64),
+    occupancy=(np.dtype(int), np.int8, np.int16, np.int32, np.int64),
     socket=to_sockets,
     charger=to_chargers,
 )
 """Schema defining a charging posts
 
 Maps the column to the dtype, a sequence of dtypes, or to an idem-potent callable that
-can be used to transform the column. All the columns named here are **required**. A
-charging posts table can any number of extra columns.
+can be used to transform the column. If  a sequence of dtypes is given, then the first
+one is the default. All the columns named here are **required**. A charging posts table
+can any number of extra columns.
 """
 
 

--- a/src/evosim/charging_posts.rst
+++ b/src/evosim/charging_posts.rst
@@ -8,25 +8,29 @@ socket type, charger type, current occupancy and maximum capacity. Potentially i
 accept other columns as well. The simplest way to generate one is to use
 :py:func:`evosim.charging_posts.random_charging_posts`:
 
-.. doctest:: charging_posts
+.. doctest:: charging_posts_usage
+    :options: +NORMALIZE_WHITESPACE
 
     >>> result = evosim.charging_posts.random_charging_posts(5, seed=1)
     >>> result
-       latitude  longitude          socket charger  capacity  occupancy
-    0     51.48       0.24             CCS    SLOW         1          0
-    1     51.68       0.95         CHADEMO    FAST         1          0
-    2     51.31       0.22             CCS   RAPID         1          0
-    3     51.68       0.46  DC_COMBO_TYPE2    SLOW         1          0
-    4     51.39      -0.45         CHADEMO    SLOW         1          0
+          latitude  longitude          socket charger  capacity  occupancy
+    post
+    0        51.48       0.24             CCS    SLOW         1          0
+    1        51.68       0.95         CHADEMO    FAST         1          0
+    2        51.31       0.22             CCS   RAPID         1          0
+    3        51.68       0.46  DC_COMBO_TYPE2    SLOW         1          0
+    4        51.39      -0.45         CHADEMO    SLOW         1          0
 
 The random ``seed`` is optional. It is provided here so that the code and output above
 can be tested reproducibly. By default, the function returns a
 :py:class:`pandas.DataFrame`. The ``socket`` and ``charger`` columns take their values
 from :py:class:`evosim.charging_posts.Sockets` and :py:class:`evosim.charging_posts.Chargers`:
 
-.. doctest:: charging_posts
+.. doctest:: charging_posts_usage
+    :options: +NORMALIZE_WHITESPACE
 
     >>> result.socket
+    post
     0               CCS
     1           CHADEMO
     2               CCS
@@ -38,6 +42,7 @@ from :py:class:`evosim.charging_posts.Sockets` and :py:class:`evosim.charging_po
     <Sockets.CCS: 32>
 
     >>> result.charger
+    post
     0     SLOW
     1     FAST
     2    RAPID
@@ -52,7 +57,8 @@ The range of latitude and longitude, the number of socket and charger types and 
 distributions can all be changed in the input. For instance, the following limits the
 sockets to two type and heavily favors one rather than the other:
 
-.. doctest:: charging_posts
+.. doctest:: charging_posts_usage
+    :options: +NORMALIZE_WHITESPACE
 
     >>> from evosim.charging_posts import Sockets
     >>> evosim.charging_posts.random_charging_posts(
@@ -62,22 +68,23 @@ sockets to two type and heavily favors one rather than the other:
     ...     capacity=(1, 5),
     ...     seed=1,
     ... )
-       latitude  longitude socket charger  capacity  occupancy
-    0     51.48       0.82  TYPE2    FAST         4          0
-    1     51.68       0.44  TYPE2    FAST         4          0
-    2     51.31       0.08  TYPE2    SLOW         2          0
-    3     51.68       0.88  TYPE2    SLOW         1          0
-    4     51.39       0.03  TYPE2    FAST         3          0
-    5     51.44       0.29  TYPE2    FAST         3          0
-    6     51.62      -0.27  TYPE2    FAST         4          0
-    7     51.43       0.21  TYPE2   RAPID         2          0
-    8     51.50      -0.14  TYPE1    FAST         2          0
-    9     51.26      -0.04  TYPE2    FAST         1          0
+          latitude  longitude socket charger  capacity  occupancy
+    post
+    0        51.48       0.82  TYPE2    FAST         4          0
+    1        51.68       0.44  TYPE2    FAST         4          0
+    2        51.31       0.08  TYPE2    SLOW         2          0
+    3        51.68       0.88  TYPE2    SLOW         1          0
+    4        51.39       0.03  TYPE2    FAST         3          0
+    5        51.44       0.29  TYPE2    FAST         3          0
+    6        51.62      -0.27  TYPE2    FAST         4          0
+    7        51.43       0.21  TYPE2   RAPID         2          0
+    8        51.50      -0.14  TYPE1    FAST         2          0
+    9        51.26      -0.04  TYPE2    FAST         1          0
 
 Both chargers and sockets can accept multiple types simultaneously, and they can be
 queried accordingly:
 
-.. doctest:: charging_posts
+.. doctest:: charging_posts_usage
     
     >>> Sockets.CCS | Sockets.TYPE1
     <Sockets.CCS|TYPE1: 33>

--- a/src/evosim/charging_posts.rst
+++ b/src/evosim/charging_posts.rst
@@ -122,13 +122,28 @@ the information back and check that it is still the same.
 
 .. testcode:: charging_posts_io
 
-    from tempfile import NamedTemporaryFile
+    from io import StringIO
     charging_posts = evosim.charging_posts.random_charging_posts(5, seed=1)
-    with NamedTemporaryFile() as file:
-        charging_posts.to_csv(file.name)
-        reread = evosim.charging_posts.to_charging_posts(pd.read_csv(file.name))
+
+    # write to file ... or to a string buffer
+    stream = StringIO()
+    charging_posts.to_csv(stream)
+
+    # read from file ... or from a string buffer
+    stream.seek(0)
+    reread = evosim.charging_posts.to_charging_posts(pd.read_csv(stream))
+
     assert evosim.charging_posts.is_charging_posts(reread)
     assert (charging_posts.round(4) == reread.round(4)).all().all()
+
+.. note::
+
+    We could just as easily write to a file with ``charging_posts.to_csv("posts.csv")``
+    and then read from it with
+    ``evosim.charging_posts.to_charging_posts(pd.read_csv("posts.csv"))``.  Instead, we
+    read and write to an object in memory that behaves like a file. This is mainly
+    because it is not allowed to write to temporary file on the windows machines where
+    the code in this manual is tested.
 
 Writing to a csv file, or to any format supported by :py:mod:`pandas` is
 straightforward. Reading from a file is also fairly straightforward, but it requires one

--- a/src/evosim/charging_posts.rst
+++ b/src/evosim/charging_posts.rst
@@ -113,8 +113,8 @@ queried accordingly:
     array([ True, False])
 
 
-Reading and writing charging posts
-----------------------------------
+Reading and writing
+-------------------
 
 The charging posts can be written and read quite easily using :py:mod:`pandas`
 capabilities in that domain. For instance, here we write to a (temporary) csv file, read
@@ -127,13 +127,17 @@ the information back and check that it is still the same.
     with NamedTemporaryFile() as file:
         charging_posts.to_csv(file.name)
         reread = evosim.charging_posts.to_charging_posts(pd.read_csv(file.name))
+    assert evosim.charging_posts.is_charging_posts(reread)
     assert (charging_posts.round(4) == reread.round(4)).all().all()
 
 Writing to a csv file, or to any format supported by :py:mod:`pandas` is
 straightforward. Reading from a file is also fairly straightforward, but it requires one
 extra step: the dataframe read from file is transformed to a charging post via
 :py:func:`evosim.charging_posts.to_charging_posts`. This ensures that the required
-columns are there and have the correct type.
+columns are there and have the correct types. In the penultimate line, we verify with
+:py:func:`evosim.charging_posts.is_charging_posts` that the transformed dataframe is
+indeed a table of charging posts.
+
 
 .. topic:: Floating point comparisons
 

--- a/src/evosim/charging_posts.rst
+++ b/src/evosim/charging_posts.rst
@@ -3,6 +3,13 @@
 Charging Posts
 ==============
 
+.. contents::
+    :depth: 2
+
+
+Usage
+-----
+
 Charging posts are represented by a table with columns for the latitude, longitude,
 socket type, charger type, current occupancy and maximum capacity. Potentially it can
 accept other columns as well. The simplest way to generate one is to use
@@ -104,3 +111,33 @@ queried accordingly:
     ...     np.array([Sockets.TYPE2, Sockets.TYPE2])
     ... ).astype(bool)
     array([ True, False])
+
+
+Reading and writing charging posts
+----------------------------------
+
+The charging posts can be written and read quite easily using :py:mod:`pandas`
+capabilities in that domain. For instance, here we write to a (temporary) csv file, read
+the information back and check that it is still the same.
+
+.. testcode:: charging_posts_io
+
+    from tempfile import NamedTemporaryFile
+    charging_posts = evosim.charging_posts.random_charging_posts(5, seed=1)
+    with NamedTemporaryFile() as file:
+        charging_posts.to_csv(file.name)
+        reread = evosim.charging_posts.to_charging_posts(pd.read_csv(file.name))
+    assert (charging_posts.round(4) == reread.round(4)).all().all()
+
+Writing to a csv file, or to any format supported by :py:mod:`pandas` is
+straightforward. Reading from a file is also fairly straightforward, but it requires one
+extra step: the dataframe read from file is transformed to a charging post via
+:py:func:`evosim.charging_posts.to_charging_posts`. This ensures that the required
+columns are there and have the correct type.
+
+.. topic:: Floating point comparisons
+
+    In the snippet above, we compare the two tables with a finite number of decimal
+    points. This is only to ensure the comparison is not influenced by how floating
+    points are represented in the csv file written out by pandas. See the option
+    `float_format` in :py:meth:`pandas.DataFrame.to_csv` for more details.

--- a/src/evosim/fleet.py
+++ b/src/evosim/fleet.py
@@ -118,5 +118,6 @@ def random_fleet(
     )
     result["model"] = rng.choice(list(model_types), size=n, replace=True)
     result["model"] = result.model.astype("category")
+    result.index.name = "vehicle"
 
     return result

--- a/src/evosim/fleet.py
+++ b/src/evosim/fleet.py
@@ -164,10 +164,10 @@ def to_models(data: Union[Sequence[Text], Text, Models]) -> Sequence[Models]:
 FLEET_SCHEMA: Mapping[
     Text, Union[np.dtype, Callable[[Sequence], Sequence], Sequence[np.dtype]]
 ] = dict(
-    latitude=np.dtype(float),
-    longitude=np.dtype(float),
-    dest_lat=np.dtype(float),
-    dest_long=np.dtype(float),
+    latitude=(np.dtype(float), np.float16, np.float32, np.float64),
+    longitude=(np.dtype(float), np.float16, np.float32, np.float64),
+    dest_lat=(np.dtype(float), np.float16, np.float32, np.float64),
+    dest_long=(np.dtype(float), np.float16, np.float32, np.float64),
     socket=to_sockets,
     charger=to_chargers,
     model=to_models,
@@ -175,8 +175,9 @@ FLEET_SCHEMA: Mapping[
 """Schema defining a fleet of electric vehicles
 
 Maps the column to the dtype, a sequence of dtypes, or to an idem-potent callable that
-can be used to transform the column. All the columns named here are **required**. A
-charging posts table can any number of extra columns.
+can be used to transform the column. If  a sequence of dtypes is given, then the first
+one is the default.All the columns named here are **required**. A charging posts table
+can any number of extra columns.
 """
 
 

--- a/src/evosim/fleet.py
+++ b/src/evosim/fleet.py
@@ -1,12 +1,12 @@
 from enum import Enum, auto
 from pathlib import Path
-from typing import Optional, Sequence, Tuple, Union
+from typing import Callable, Mapping, Optional, Sequence, Text, Tuple, Union
 
 import numpy as np
 import pandas as pd
 
 from evosim import constants
-from evosim.charging_posts import Chargers, Sockets
+from evosim.charging_posts import Chargers, Sockets, to_chargers, to_sockets
 
 __doc__ = Path(__file__).with_suffix(".rst").read_text()
 
@@ -121,3 +121,149 @@ def random_fleet(
     result.index.name = "vehicle"
 
     return result
+
+
+def to_models(data: Union[Sequence[Text], Text, Models]) -> Sequence[Models]:
+    """Transforms text strings to sockets.
+
+    Example:
+
+        String to models:
+
+        >>> from evosim.fleet import to_models
+        >>> to_models("BMW_i3")
+        <Models.BMW_I3: 2>
+
+        Lists of strings to lists models:
+
+        >>> to_models(["BMW_i3", "tesla_model_s"])
+        [<Models.BMW_I3: 2>, <Models.TESLA_MODEL_S: 23>]
+
+        Numpy arrays of strings to numpy arrays of models:
+
+        >>> to_models(np.array(["BMW_i3", "TESLA_MODEL_S"]))
+        array([<Models.BMW_I3: 2>, <Models.TESLA_MODEL_S: 23>], dtype=object)
+
+        Pandas series to pandas series:
+
+        >>> to_models(pd.Series(["bmw_i3", "tesla_model_s"], index=['a', 'b']))
+        a           BMW_I3
+        b    TESLA_MODEL_S
+        dtype: object
+
+        Or models to models...
+
+        >>> to_models(evosim.fleet.Models.BMW_I3)
+        <Models.BMW_I3: 2>
+    """
+    from evosim.charging_posts import _to_enum
+
+    return _to_enum(data, Models, "model")
+
+
+FLEET_SCHEMA: Mapping[
+    Text, Union[np.dtype, Callable[[Sequence], Sequence], Sequence[np.dtype]]
+] = dict(
+    latitude=np.dtype(float),
+    longitude=np.dtype(float),
+    dest_lat=np.dtype(float),
+    dest_long=np.dtype(float),
+    socket=to_sockets,
+    charger=to_chargers,
+    model=to_models,
+)
+"""Schema defining a fleet of electric vehicles
+
+Maps the column to the dtype, a sequence of dtypes, or to an idem-potent callable that
+can be used to transform the column. All the columns named here are **required**. A
+charging posts table can any number of extra columns.
+"""
+
+
+def is_fleet(dataframe: pd.DataFrame, raise_exception: bool = False) -> bool:
+    """True if dataframe follows the fleet schema.
+
+    Args:
+        dataframe (pandas.DataFrame): putative fleet of electric vehicles
+        raise_exception: if ``False`` returns a boolean. If ``True``, will raise an
+            exception with some information identifying the difference with
+            :py:data:`FLEET_SCHEMA`.
+
+    Usage:
+
+        >>> from pytest import raises
+        >>> from evosim.fleet import random_fleet, is_fleet
+        >>> fleet = random_fleet(5)
+        >>> is_fleet(fleet)
+        True
+
+        >>> is_fleet(fleet.drop(columns="latitude"))
+        False
+
+        >>> wrong_dtype = fleet.copy(deep=False)
+        >>> wrong_dtype["latitude"] = wrong_dtype.latitude.astype(str)
+        >>> is_fleet(wrong_dtype)
+        False
+
+        >>> wrong_dtype = fleet.copy(deep=False)
+        >>> wrong_dtype["socket"] = [str(u).lower() for u in wrong_dtype.socket]
+        >>> is_fleet(wrong_dtype)
+        False
+
+        >>> wrong_index_name = fleet.copy(deep=False)
+        >>> wrong_index_name.index.name = "notvehicle"
+        >>> is_fleet(wrong_index_name)
+        False
+        >>> wrong_index_name.index.name = "VEHICLE"
+        >>> is_fleet(wrong_index_name)
+        False
+
+        >>> with raises(ValueError):
+        ...     is_fleet(fleet.drop(columns="latitude"), raise_exception=True)
+    """
+    from evosim.charging_posts import _dataframe_follows_schema
+    from evosim.fleet import FLEET_SCHEMA
+
+    return _dataframe_follows_schema(
+        dataframe,
+        raise_exception=raise_exception,
+        schema=FLEET_SCHEMA,
+        index_name="vehicle",
+    )
+
+
+def to_fleet(data: pd.DataFrame) -> pd.DataFrame:
+    """Tries and transform input data to a fleet dataframe.
+
+    This function will try and transform the columns of the input dataframe to fit the
+    schema defined in :py:data:`evosim.fleet.FLEET_SCHEMA`. It also sets the "vehicle"
+    column as the index, if it exists. In any-case, it names the indices "vehicle". It
+    returns a shallow copy of the input data frame with transformed columns as required.
+
+    Args:
+        data (pandas.DataFrame): dataframe to transform following the schema.
+
+    Returns:
+        pandas.DataFrame: A dataframe conforming to the fleet schema.
+
+    Example:
+
+        >>> from evosim.fleet import random_fleet, to_fleet, is_fleet
+        >>> from evosim.charging_posts import Sockets, Chargers
+        >>> dataframe = random_fleet(5)
+        >>> dataframe["socket"] = [str(u).lower() for u in dataframe.socket]
+        >>> dataframe["charger"] = [str(u).lower() for u in dataframe.charger]
+        >>> is_fleet(dataframe)
+        False
+        >>> fleet = to_fleet(dataframe)
+        >>> is_fleet(fleet)
+        True
+        >>> isinstance(fleet.at[0, "socket"], Sockets)
+        True
+        >>> isinstance(fleet.at[0, "charger"], Chargers)
+        True
+    """
+    from evosim.charging_posts import _transform_to_schema
+    from evosim.fleet import FLEET_SCHEMA
+
+    return _transform_to_schema(FLEET_SCHEMA, data, index_name="vehicle")

--- a/src/evosim/fleet.rst
+++ b/src/evosim/fleet.rst
@@ -80,15 +80,29 @@ The fleets can be written and read quite easily using :py:mod:`pandas` capabilit
 that domain. For instance, here we write to a (temporary) csv file, read the information
 back and check that it is still the same.
 
-.. testcode:: charging_posts_io
+.. testcode:: fleet_io
 
-    from tempfile import NamedTemporaryFile
+    from io import StringIO
     fleet = evosim.fleet.random_fleet(5, seed=1)
-    with NamedTemporaryFile() as file:
-        fleet.to_csv(file.name)
-        reread = evosim.fleet.to_fleet(pd.read_csv(file.name))
+
+    # write to file ... or to a string buffer
+    stream = StringIO()
+    fleet.to_csv(stream)
+
+    # read from file ... or from a string buffer
+    stream.seek(0)
+    reread = evosim.fleet.to_fleet(pd.read_csv(stream))
+
     assert evosim.fleet.is_fleet(reread)
     assert (fleet.round(4) == reread.round(4)).all().all()
+
+.. note::
+
+    We could just as easily write to a file with ``fleet.to_csv("fleet.csv")`` and then
+    read from it with ``evosim.fleet.to_fleet(pd.read_csv("fleet.csv"))``.  Instead, we
+    read and write to an object in memory that behaves like a file. This is mainly
+    because it is not allowed to write to temporary file on the windows machines where
+    the code in this manual is tested.
 
 Writing to a csv file, or to any format supported by :py:mod:`pandas` is
 straightforward. Reading from a file is also fairly straightforward, but it requires one

--- a/src/evosim/fleet.rst
+++ b/src/evosim/fleet.rst
@@ -11,19 +11,21 @@ simplest way to generate a fleet is to use :py:func:`evosim.fleet.random_fleet`:
 
     >>> result = evosim.fleet.random_fleet(5, seed=1)
     >>> result
-       latitude  longitude          socket charger  dest_lat  dest_long  \
-    0     51.48       0.24             CCS    SLOW     51.45   8.13e-01
-    1     51.68       0.95         CHADEMO    FAST     51.31  -9.28e-03
-    2     51.31       0.22             CCS   RAPID     51.43   3.49e-01
-    3     51.68       0.46  DC_COMBO_TYPE2    SLOW     51.34   1.22e+00
-    4     51.39      -0.45         CHADEMO    SLOW     51.37   1.18e+00
+             latitude  longitude          socket charger  dest_lat  dest_long  \
+    vehicle
+    0           51.48       0.24             CCS    SLOW     51.45   8.13e-01
+    1           51.68       0.95         CHADEMO    FAST     51.31  -9.28e-03
+    2           51.31       0.22             CCS   RAPID     51.43   3.49e-01
+    3           51.68       0.46  DC_COMBO_TYPE2    SLOW     51.34   1.22e+00
+    4           51.39      -0.45         CHADEMO    SLOW     51.37   1.18e+00
     <BLANKLINE>
-                        model
-    0               BMW_225XE
-    1           TESLA_MODEL_X
-    2           KIA_NIRO_PHEV
-    3             NISSAN_LEAF
-    4  VOLVO_XC90_TWIN_ENGINE
+                              model
+    vehicle
+    0                     BMW_225XE
+    1                 TESLA_MODEL_X
+    2                 KIA_NIRO_PHEV
+    3                   NISSAN_LEAF
+    4        VOLVO_XC90_TWIN_ENGINE
 
 Much as the chargers and sockets, the models are a categorical array taking their values
 from :py:class:`evosim.fleet.Models`:
@@ -31,6 +33,7 @@ from :py:class:`evosim.fleet.Models`:
 .. doctest:: EVs
 
     >>> result.model
+    vehicle
     0                 BMW_225XE
     1             TESLA_MODEL_X
     2             KIA_NIRO_PHEV
@@ -47,16 +50,18 @@ instance, we can create electric vehicles accepting multiple types of sockets:
     :options: +NORMALIZE_WHITESPACE
 
     >>> evosim.fleet.random_fleet(5, socket_multiplicity=3, seed=1)
-       latitude  longitude                  socket charger  dest_lat  dest_long  \
-    0     51.48       0.24                     CCS    SLOW     51.69      -0.22
-    1     51.68       0.95  CHADEMO|DC_COMBO_TYPE2   RAPID     51.68       1.20
-    2     51.31       0.22        THREE_PIN_SQUARE    SLOW     51.58       0.40
-    3     51.68       0.46             TYPE2|TYPE1    SLOW     51.49      -0.30
-    4     51.39      -0.45                     CCS    FAST     51.37       0.59
+             latitude  longitude                  socket charger  dest_lat  dest_long  \
+    vehicle
+    0           51.48       0.24                     CCS    SLOW     51.69      -0.22
+    1           51.68       0.95  CHADEMO|DC_COMBO_TYPE2   RAPID     51.68       1.20
+    2           51.31       0.22        THREE_PIN_SQUARE    SLOW     51.58       0.40
+    3           51.68       0.46             TYPE2|TYPE1    SLOW     51.49      -0.30
+    4           51.39      -0.45                     CCS    FAST     51.37       0.59
     <BLANKLINE>
-                           model
-    0  MITSUBISHI_OUTLANDER_PHEV
-    1  MINI_COUNTRYMAN_COOPER_SE
-    2        TOYOTA_PRIUS_PLUGIN
-    3       HYUNDAI_IONIQ_PLUGIN
-    4                RENAULT_ZOE
+                                 model
+    vehicle
+    0        MITSUBISHI_OUTLANDER_PHEV
+    1        MINI_COUNTRYMAN_COOPER_SE
+    2              TOYOTA_PRIUS_PLUGIN
+    3             HYUNDAI_IONIQ_PLUGIN
+    4                      RENAULT_ZOE

--- a/src/evosim/fleet.rst
+++ b/src/evosim/fleet.rst
@@ -1,6 +1,12 @@
 Electric Vehicles
 =================
 
+.. contents::
+    :depth: 2
+
+Usage
+-----
+
 A fleet of electric vehicles are defined in a similar fashion to :ref:`charging-posts`.
 Indeed, the fleet contains the same attributes, e.g. current latitude and longitude,
 socket and charger type, as well as extra attributes, such as the car model.  The
@@ -65,3 +71,35 @@ instance, we can create electric vehicles accepting multiple types of sockets:
     2              TOYOTA_PRIUS_PLUGIN
     3             HYUNDAI_IONIQ_PLUGIN
     4                      RENAULT_ZOE
+
+
+Reading and writing fleets
+--------------------------
+
+The fleets can be written and read quite easily using :py:mod:`pandas` capabilities in
+that domain. For instance, here we write to a (temporary) csv file, read the information
+back and check that it is still the same.
+
+.. testcode:: charging_posts_io
+
+    from tempfile import NamedTemporaryFile
+    fleet = evosim.fleet.random_fleet(5, seed=1)
+    with NamedTemporaryFile() as file:
+        fleet.to_csv(file.name)
+        reread = evosim.fleet.to_fleet(pd.read_csv(file.name))
+    assert evosim.fleet.is_fleet(reread)
+    assert (fleet.round(4) == reread.round(4)).all().all()
+
+Writing to a csv file, or to any format supported by :py:mod:`pandas` is
+straightforward. Reading from a file is also fairly straightforward, but it requires one
+extra step: the dataframe read from file is transformed to a charging post via
+:py:func:`evosim.fleet.to_fleet`. This ensures that the required columns are there and
+have the correct types. In the penultimate line, we verify with
+:py:func:`evosim.fleet.is_fleet` that the transformed dataframe is indeed a fleet.
+
+.. topic:: Floating point comparisons
+
+    In the snippet above, we compare the two tables with a finite number of decimal
+    points. This is only to ensure the comparison is not influenced by how floating
+    points are represented in the csv file written out by pandas. See the option
+    `float_format` in :py:meth:`pandas.DataFrame.to_csv` for more details.

--- a/src/evosim/matchers.py
+++ b/src/evosim/matchers.py
@@ -35,6 +35,7 @@ def charging_post_availability(_, charging_post) -> bool:
         >>> evosim.matchers.charging_post_availability(None, cps.loc[0])
         True
         >>> evosim.matchers.charging_post_availability(None, cps)
+        post
         0    True
         1    True
         2    True

--- a/src/evosim/matchers.rst
+++ b/src/evosim/matchers.rst
@@ -19,6 +19,7 @@ accessed directly or created via :py:mod:`evosim.matchers.factory`:
     >>> infrastructure = evosim.charging_posts.random_charging_posts(5, seed=1)
     >>> fleet = evosim.fleet.random_fleet(10, seed=1)
     >>> matcher(fleet, infrastructure.loc[0])
+    vehicle
     0    False
     1    False
     2    False
@@ -44,6 +45,7 @@ Using the factory becomes interesting when we want to apply a combination of mat
     ...     ["socket_compatibility", "charger_compatibility"]
     ... )
     >>> matcher(fleet, infrastructure.loc[0])
+    vehicle
     0    False
     1    False
     2    False
@@ -65,6 +67,7 @@ form of keyword arguments. These parameters can be set from the outset by feedin
     
     >>> dmatcher = evosim.matchers.factory({"name": "distance", "max_distance": 10})
     >>> dmatcher(fleet, infrastructure.loc[1])
+    vehicle
     0    False
     1    False
     2    False
@@ -79,6 +82,7 @@ form of keyword arguments. These parameters can be set from the outset by feedin
 
     >>> dmatcher = evosim.matchers.factory({"name": "distance", "max_distance": 30})
     >>> dmatcher(fleet, infrastructure.loc[1])
+    vehicle
     0     True
     1    False
     2    False
@@ -124,6 +128,7 @@ However, a subset with the same indices can be compared:
     >>> with raises(TypeError):
     ...     matcher(fleet.loc[:10], infrastructure.loc[10:20])
     >>> matcher(fleet.loc[10:20], infrastructure.loc[10:20])
+    vehicle
     10    False
     11    False
     12    False
@@ -146,6 +151,7 @@ from the fleet to the charging posts:
     >>> random_assignation = rng.choice(infrastructure.index, size=len(fleet))
     >>> assigned_posts = infrastructure.loc[random_assignation].set_index(fleet.index)
     >>> matcher(fleet, assigned_posts).sample(5, random_state=29)
+    vehicle
     73    False
     8     False
     10    False

--- a/src/evosim/objectives.rst
+++ b/src/evosim/objectives.rst
@@ -22,6 +22,7 @@ They can be used as follows:
     >>> a = evosim.charging_posts.random_charging_posts(5, seed=1)
     >>> b = evosim.charging_posts.random_charging_posts(5, seed=2)
     >>> evosim.objectives.distance(a, b)
+    post
     0    41.30
     1    88.79
     2    57.54


### PR DESCRIPTION
Adds reading and writing to and from file formats pandas knows about. It include csv, feather, parquet, sql, ... even the clipboard. This PR does not include reading from the data files as sent by @DT16. That will require some data munging and a specialized function in a subsequent PR.